### PR TITLE
Fix Undo/Redo TOC anchor in editor workflows doc

### DIFF
--- a/docs/EDITOR_WORKFLOWS.md
+++ b/docs/EDITOR_WORKFLOWS.md
@@ -8,7 +8,7 @@ This document describes the common workflows and features available in the Limbo
 - [Editor Layout](#editor-layout)
 - [Entity Management](#entity-management)
 - [Transform Gizmos](#transform-gizmos)
-- [Undo/Redo System](#undoredo-system)
+- [Undo/Redo System](#undo-redo-system)
 - [Play Mode](#play-mode)
 - [Asset Browser](#asset-browser)
 - [Keyboard Shortcuts](#keyboard-shortcuts)


### PR DESCRIPTION
### Motivation

- The Table of Contents entry for the Undo/Redo section used an incorrect anchor (`#undoredo-system`) that did not match the heading slug. 
- This caused the TOC link to jump to the wrong location or not work in rendered Markdown. 
- The change restores correct intra-document navigation for the Editor Workflows documentation.

### Description

- Update the TOC entry in `docs/EDITOR_WORKFLOWS.md` by replacing `- [Undo/Redo System](#undoredo-system)` with `- [Undo/Redo System](#undo-redo-system)`. 
- Confirmed the corresponding heading is `## Undo/Redo System`, which matches the new anchor. 

### Testing

- No automated tests were run because this is a documentation-only change. 
- Verified the file was updated and the TOC line now references the correct anchor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963451af8a88333927f1595abc849f5)